### PR TITLE
Exclude multi-selections from being decorated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,10 +82,12 @@ function process(): void {
 	}
 
 	// Exclude selected ones
-	const selection = editor.selection;
+	const selections = editor.selections;
 	const sets = decoratorSets.filter(d =>
-		(selection.start.line > d.start.line || d.start.line > selection.end.line) &&
-		(selection.start.line > d.end.line || d.start.line > selection.end.line)
+		// for every selection in the editor, it must not intersect the decorator's range
+		selections.every(selection =>
+			((selection.start.line > d.end.line) || (selection.end.line < d.start.line))
+		)
 	);
 
 	// Grouping


### PR DESCRIPTION
I noticed a bug where selecting with multiple cursors (default mouse middle-click and drag), the link text would still be displayed for all but one of the selections.
Before:
![image](https://user-images.githubusercontent.com/33101443/130715047-c03f7797-0a33-4f3f-9361-1c49ccb1d534.png)
After:
![image](https://user-images.githubusercontent.com/33101443/130715075-1344ebd2-797e-4dc2-ac93-628a30d1bf98.png)
