### PR TITLE
feat: provide document links for local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ const hiddenDecorationType = vs.window.createTextEditorDecorationType({
 });
 
 const commentPattern = /\/\*\*(.+?)\*\//gs;
-const linkPattern = /(\{@link\s+)([^|}\s]+)(?:[|\s]\s*([^}\s][^}]*)|\s+)?\}/gs;
+const linkPattern = /(\{@link(?:code)?\s+)([^|}\s]+)(?:[|\s]\s*([^}\s][^}]*)|\s+)?\}/gs;
 
 const supportedLang = ['javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue'];
 


### PR DESCRIPTION
This change allows the links to be clicked when they point to a local, relative file path. For example:

Click the link here
<img width="542" alt="Screen Shot 2021-09-22 at 1 31 01 PM" src="https://user-images.githubusercontent.com/760204/134417389-c9b599c3-7d1f-4152-a8dd-fd2c8ed70b3f.png">

And you will open the `package.json` file.
<img width="748" alt="Screen Shot 2021-09-22 at 1 31 09 PM" src="https://user-images.githubusercontent.com/760204/134417400-2355b851-da29-40a2-8511-09fc245e82e1.png">

`@link file:../package.json` will also work.

This also supports the `@linkcode` tag, see under [synonyms for @link](https://jsdoc.app/tags-inline-link.html)